### PR TITLE
Improve student activity registration system

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister participants from activities
 
 ## Getting Started
 
@@ -31,6 +32,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/participants?email=student@mergington.edu` | Remove a participant from an activity                          |
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_from_activity(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -102,6 +102,9 @@ def signup_for_activity(activity_name: str, email: str):
     if email in activity["participants"]:
         raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
+    # Validate activity is not already at capacity
+    if "max_participants" in activity and len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=409, detail="Activity is full")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for varsity and JV levels",
+        "schedule": "Mondays, Wednesdays, Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn tennis skills and participate in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["jessica@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["lucas@mergington.edu", "ava@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Participate in theatrical productions and performances",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["noah@mergington.edu", "mia@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore STEM topics",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["ethan@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,15 +3,92 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const defaultActivityOption = '<option value="">-- Select an activity --</option>';
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function createParticipantListItem(activityName, participant) {
+    const participantItem = document.createElement("li");
+    participantItem.className = "participant-item";
+
+    const participantEmail = document.createElement("span");
+    participantEmail.className = "participant-email";
+    participantEmail.textContent = participant;
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.className = "participant-remove-button";
+    removeButton.dataset.activity = activityName;
+    removeButton.dataset.email = participant;
+    removeButton.setAttribute("aria-label", `Unregister ${participant} from ${activityName}`);
+    removeButton.textContent = "✕";
+
+    participantItem.append(participantEmail, removeButton);
+    return participantItem;
+  }
+
+  function createParticipantList(activityName, participants) {
+    const participantsList = document.createElement("ul");
+    participantsList.className = "participants-list";
+
+    if (participants.length === 0) {
+      const emptyState = document.createElement("li");
+      emptyState.className = "empty-state";
+      emptyState.textContent = "No students signed up yet.";
+      participantsList.appendChild(emptyState);
+      return participantsList;
+    }
+
+    participants.forEach((participant) => {
+      participantsList.appendChild(createParticipantListItem(activityName, participant));
+    });
+
+    return participantsList;
+  }
+
+  async function unregisterParticipant(activityName, email) {
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activityName)}/participants?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Could not remove participant.", "error");
+        return;
+      }
+
+      showMessage(result.message, "success");
+      await fetchActivities();
+    } catch (error) {
+      showMessage("Failed to remove participant. Please try again.", "error");
+      console.error("Error removing participant:", error);
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", {
+        cache: "no-store",
+      });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = defaultActivityOption;
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -21,11 +98,19 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft = details.max_participants - details.participants.length;
 
         activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
+          <div class="activity-card-header">
+            <h4>${name}</h4>
+            <span class="spots-badge">${spotsLeft} spots left</span>
+          </div>
+          <p class="activity-description">${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title">Current Participants</p>
+          </div>
         `;
+
+        const participantsSection = activityCard.querySelector(".participants-section");
+        participantsSection.appendChild(createParticipantList(name, details.participants));
 
         activitiesList.appendChild(activityCard);
 
@@ -40,6 +125,16 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error fetching activities:", error);
     }
   }
+
+  activitiesList.addEventListener("click", (event) => {
+    const removeButton = event.target.closest(".participant-remove-button");
+
+    if (!removeButton) {
+      return;
+    }
+
+    unregisterParticipant(removeButton.dataset.activity, removeButton.dataset.email);
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
@@ -59,28 +154,18 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
-  fetchActivities();
+  void fetchActivities();
 });

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,20 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
   const defaultActivityOption = '<option value="">-- Select an activity --</option>';
+  let messageHideTimeoutId;
 
   function showMessage(text, type) {
     messageDiv.textContent = text;
     messageDiv.className = type;
     messageDiv.classList.remove("hidden");
 
-    setTimeout(() => {
+    if (messageHideTimeoutId) {
+      clearTimeout(messageHideTimeoutId);
+    }
+
+    messageHideTimeoutId = setTimeout(() => {
       messageDiv.classList.add("hidden");
+      messageHideTimeoutId = undefined;
     }, 5000);
   }
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -59,10 +59,11 @@ section h3 {
 
 .activity-card {
   margin-bottom: 15px;
-  padding: 15px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  background-color: #f9f9f9;
+  padding: 18px;
+  border: 1px solid #d7def5;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #ffffff 0%, #f6f8ff 100%);
+  box-shadow: 0 12px 24px rgba(26, 35, 126, 0.08);
 }
 
 .activity-card h4 {
@@ -72,6 +73,95 @@ section h3 {
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+.activity-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.activity-description {
+  color: #4b5563;
+}
+
+.spots-badge {
+  white-space: nowrap;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background-color: #e8eaf6;
+  color: #1a237e;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.participants-section {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 12px;
+  background-color: #eef3ff;
+  border: 1px solid #d7def5;
+}
+
+.participants-title {
+  margin-bottom: 10px;
+  color: #1a237e;
+  font-weight: bold;
+}
+
+.participants-list {
+  list-style: none;
+  padding-left: 0;
+  color: #24324a;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.participant-remove-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 999px;
+  background-color: #ffe5e5;
+  color: #b42318;
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.participant-remove-button:hover {
+  background-color: #ffc9c9;
+}
+
+.empty-state {
+  list-style: none;
+  color: #6b7280;
+  font-style: italic;
 }
 
 .form-group {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,8 @@ ORIGINAL_ACTIVITIES = deepcopy(activities)
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    with TestClient(app) as client:
+        yield client
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+ORIGINAL_ACTIVITIES = deepcopy(activities)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    activities.clear()
+    activities.update(deepcopy(ORIGINAL_ACTIVITIES))
+    yield

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,6 +71,37 @@ def test_signup_rejects_duplicate_participant(client):
     assert activities[activity_name]["participants"].count(email) == 1
 
 
+def test_signup_rejects_when_activity_at_capacity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    max_participants = activities[activity_name]["max_participants"]
+    current_participants = list(activities[activity_name]["participants"])
+    remaining_slots = max_participants - len(current_participants)
+
+    # Fill the activity to its maximum capacity
+    for i in range(remaining_slots):
+        email = f"student{i}@mergington.edu"
+        response = client.post(
+            f"/activities/{activity_name}/signup",
+            params={"email": email},
+        )
+        assert response.status_code == 200
+
+    assert len(activities[activity_name]["participants"]) == max_participants
+
+    extra_email = "extra.student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": extra_email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Activity is at full capacity"}
+    assert len(activities[activity_name]["participants"]) == max_participants
+    assert extra_email not in activities[activity_name]["participants"]
 def test_unregister_removes_participant_from_activity(client):
     # Arrange
     activity_name = "Chess Club"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,120 @@
+from src.app import activities
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_activity_data(client):
+    # Arrange
+
+    # Act
+    response = client.get("/activities")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert "Chess Club" in payload
+    assert payload["Chess Club"] == {
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+    }
+
+
+def test_signup_adds_participant_to_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Robotics Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_signup_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Student already signed up for this activity"}
+    assert activities[activity_name]["participants"].count(email) == 1
+
+
+def test_unregister_removes_participant_from_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Removed {email} from {activity_name}"}
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Robotics Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_unregister_returns_not_found_for_missing_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Student not signed up for this activity"}


### PR DESCRIPTION
This pull request adds the ability for students to unregister from extracurricular activities, improves the user interface for managing participants, and introduces comprehensive backend tests. It also expands the set of available activities and enhances the frontend experience for both signing up and removing participants.

**Backend functionality:**

* Added a new API endpoint (`DELETE /activities/{activity_name}/participants?email=...`) to allow students to unregister from activities, with appropriate error handling for unknown activities and missing participants. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R35) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R101-R122)
* Expanded the list of available activities in the `activities` data model, including Basketball Team, Tennis Club, Art Studio, Drama Club, Debate Team, and Science Club.

**Frontend improvements:**

* Updated the UI to display a list of current participants for each activity, including the ability to remove (unregister) participants directly from the interface. Added feedback messages for success and error cases. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R6-R91) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R101-R114) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R129-R138) [[4]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R170)
* Restyled activity cards and participant lists for improved readability and user experience, including badges for available spots and enhanced visual grouping. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2L62-R66) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R78-R166)

**Testing and configuration:**

* Added a comprehensive test suite for all major API endpoints, including tests for signing up, unregistering, error cases, and data integrity.
* Introduced a test fixture to reset the activities data before each test and configured pytest to use the `tests` directory. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R21) [[2]](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R3)

**Documentation:**

* Updated the `README.md` to document the new unregister feature and corresponding API endpoint. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R9) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R35)